### PR TITLE
Create head include, do SEO additions

### DIFF
--- a/main_site/views/include/head.ejs
+++ b/main_site/views/include/head.ejs
@@ -1,0 +1,59 @@
+<head>
+  <meta charset="utf-8">
+  <meta content="width=device-width, initial-scale=1.0" name="viewport">
+  
+  <title>Robotronics Club, IIT Mandi</title>
+
+  <meta name="description" content="Website for Robotronics Club, IIT Mandi.">
+  <meta name="keywords" content="Robotics, Electronics, Robotronics, IIT, Mandi, Indian Institute of Technology, Robot, Technology, Technical Club">
+  <meta name="author" content="Core Team, Robotronics Club, IIT Mandi">
+  <!-- <script src="https://www.gstatic.com/firebasejs/7.13.1/firebase-app.js"></script> -->
+
+  <!-- TODO: Add SDKs for Firebase products that you want to use
+      https://firebase.google.com/docs/web/setup#available-libraries -->
+  <!-- <script src="https://www.gstatic.com/firebasejs/7.13.1/firebase-firestore.js"></script> -->
+
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css">
+  <link href="//db.onlinewebfonts.com/c/d1a880e08bdb2140abd96f8f8d2d9515?family=Bloc" rel="stylesheet" type="text/css"/>
+  <!-- Favicons -->
+  <link href="assets/img/logo.png" rel="icon">
+  <link href="assets/img/apple-touch-icon.png" rel="apple-touch-icon">
+
+  <!-- Google Fonts -->
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Roboto:300,300i,400,400i,500,500i,700,700i|Poppins:300,300i,400,400i,500,500i,600,600i,700,700i" rel="stylesheet">
+
+  <!-- Vendor CSS Files -->
+  
+  <link href="assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+  <link href="assets/vendor/icofont/icofont.min.css" rel="stylesheet">
+  <link href="assets/vendor/boxicons/css/boxicons.min.css" rel="stylesheet">
+  <link href="assets/vendor/animate.css/animate.min.css" rel="stylesheet">
+  <!-- <link href="assets/vendor/venobox/venobox.css" rel="stylesheet"> -->
+
+  <!-- Template Main CSS File -->
+  <link href="assets/css/style.css" rel="stylesheet">
+
+  <!-- Preloader css -->
+  <link href="stylesheets/preloader.css" rel="stylesheet">
+
+  <!-- If no javascript is enable in browser, it will never be shown so, -->
+  <!-- noscript allowed in HTML5 in head -->
+  <noscript>
+    <style>
+      #loader {
+        display: none;
+      }
+     
+      #show-after-load {
+        display: block;
+      }
+    </style>
+  </noscript>
+
+  <!-- =======================================================
+  * Template Name: Shuffle - v2.0.0
+  * Template URL: https://bootstrapmade.com/bootstrap-3-one-page-template-free-shuffle/
+  * Author: BootstrapMade.com
+  * License: https://bootstrapmade.com/license/
+  ======================================================== -->
+</head>


### PR DESCRIPTION
- Just like the footer include, a template head include for all the pages that require it. 
- Have added a few more SEO details with minor corrections.
- This file can now be added as an include to all the files that require a `head` tag.